### PR TITLE
Update repo URLs from book-dp1-public to book-dp-public

### DIFF
--- a/website/code.html
+++ b/website/code.html
@@ -38,11 +38,11 @@
                         <tbody>
                             <tr>
                                 <td>Julia</td>
-                                <td><a href="https://github.com/QuantEcon/book-dp1-public/tree/main/code/jl">Files on GitHub</a></td>
+                                <td><a href="https://github.com/QuantEcon/book-dp-public/tree/main/code/jl">Files on GitHub</a></td>
                             </tr>
                             <tr>
                                 <td>Python</td>
-                                <td><a href="https://github.com/QuantEcon/book-dp1-public/tree/main/code/py">Files on GitHub</a></td>
+                                <td><a href="https://github.com/QuantEcon/book-dp-public/tree/main/code/py">Files on GitHub</a></td>
                             </tr>
                         </tbody>
                     </table>
@@ -58,7 +58,7 @@
                 <div class="align-center">
                     <ul class="actions fit">
                         <li>
-                            <a href="https://github.com/QuantEcon/book-dp1-public/" class="button fit"><img src="images/github-mark.png" width="15" alt="GitHub icon">GitHub</a>
+                            <a href="https://github.com/QuantEcon/book-dp-public/" class="button fit"><img src="images/github-mark.png" width="15" alt="GitHub icon">GitHub</a>
                         </li>
                         <li>
                             <a href="https://quantecon.org" class="button fit"><img src="images/qe-logo-small.png" width="25" alt="QuantEcon icon">QuantEcon</a>

--- a/website/index.html
+++ b/website/index.html
@@ -30,9 +30,9 @@
         <div class="amazon-link-container">
             <a href="https://www.amazon.com/Dynamic-Programming-Finite-Thomas-Sargent/dp/1009540750/" class="amazon-button">Buy on Amazon<span class="amazon-vol">(Volume I)</span></a>
             <div class="download-links">
-                <a href="https://github.com/QuantEcon/book-dp1-public/raw/main/pdf/dp.pdf" class="download-button">Download Vol I (PDF)</a>
+                <a href="https://github.com/QuantEcon/book-dp-public/raw/main/pdf/dp.pdf" class="download-button">Download Vol I (PDF)</a>
                 <span class="download-sep">&middot;</span>
-                <a href="https://github.com/QuantEcon/book-dp1-public/raw/main/pdf/dp2.pdf" class="download-button">Download Vol II (PDF)</a>
+                <a href="https://github.com/QuantEcon/book-dp-public/raw/main/pdf/dp2.pdf" class="download-button">Download Vol II (PDF)</a>
             </div>
         </div>
     </header>
@@ -103,7 +103,7 @@
             <div class="align-center">
                 <ul class="actions fit">
                     <li>
-                        <a href="https://github.com/QuantEcon/book-dp1-public/raw/main/pdf/dp.pdf" class="button fit"><img src="images/book.png" width="15" alt="Book icon">Book (PDF)</a>
+                        <a href="https://github.com/QuantEcon/book-dp-public/raw/main/pdf/dp.pdf" class="button fit"><img src="images/book.png" width="15" alt="Book icon">Book (PDF)</a>
                     </li>
                     <li>
                         <a href="code.html" class="button fit"><img src="images/book.png" width="15" alt="Code icon">Code</a>
@@ -117,7 +117,7 @@
             <div class="align-center">
                 <ul class="actions fit">
                     <li>
-                        <a href="https://github.com/QuantEcon/book-dp1-public/raw/main/pdf/dp2.pdf" class="button fit"><img src="images/book.png" width="15" alt="Book icon">Book (PDF)</a>
+                        <a href="https://github.com/QuantEcon/book-dp-public/raw/main/pdf/dp2.pdf" class="button fit"><img src="images/book.png" width="15" alt="Book icon">Book (PDF)</a>
                     </li>
                 </ul>
             </div>
@@ -128,7 +128,7 @@
             <header class="major">
                 <h2>Feedback</h2>
             </header>
-            <p>We welcome all feedback. Please contact us by email or submit an issue/pull request to the <a href="https://github.com/QuantEcon/book-dp1-public/">GitHub repository</a>.</p>
+            <p>We welcome all feedback. Please contact us by email or submit an issue/pull request to the <a href="https://github.com/QuantEcon/book-dp-public/">GitHub repository</a>.</p>
         </section>
 
         <!-- Links -->
@@ -139,7 +139,7 @@
             <div class="align-center">
                 <ul class="actions fit">
                     <li>
-                        <a href="https://github.com/QuantEcon/book-dp1-public/" class="button fit"><img src="images/github-mark.png" width="15" alt="GitHub icon">GitHub</a>
+                        <a href="https://github.com/QuantEcon/book-dp-public/" class="button fit"><img src="images/github-mark.png" width="15" alt="GitHub icon">GitHub</a>
                     </li>
                     <li>
                         <a href="https://quantecon.org" class="button fit"><img src="images/qe-logo-small.png" width="25" alt="QuantEcon icon">QuantEcon</a>

--- a/website/slides.html
+++ b/website/slides.html
@@ -38,47 +38,47 @@
                         <tbody>
                             <tr>
                                 <td>Chapter 0</td>
-                                <td><a href="https://github.com/QuantEcon/book-dp1-public/raw/main/slides/ch_0.pdf">Preface and Overview</a></td>
+                                <td><a href="https://github.com/QuantEcon/book-dp-public/raw/main/slides/ch_0.pdf">Preface and Overview</a></td>
                             </tr>
                             <tr>
                                 <td>Chapter 1</td>
-                                <td><a href="https://github.com/QuantEcon/book-dp1-public/raw/main/slides/ch_1.pdf">Introduction</a></td>
+                                <td><a href="https://github.com/QuantEcon/book-dp-public/raw/main/slides/ch_1.pdf">Introduction</a></td>
                             </tr>
                             <tr>
                                 <td>Chapter 2</td>
-                                <td><a href="https://github.com/QuantEcon/book-dp1-public/raw/main/slides/ch_2.pdf">Operators and Fixed Points</a></td>
+                                <td><a href="https://github.com/QuantEcon/book-dp-public/raw/main/slides/ch_2.pdf">Operators and Fixed Points</a></td>
                             </tr>
                             <tr>
                                 <td>Chapter 3</td>
-                                <td><a href="https://github.com/QuantEcon/book-dp1-public/raw/main/slides/ch_3.pdf">Markov Dynamics</a></td>
+                                <td><a href="https://github.com/QuantEcon/book-dp-public/raw/main/slides/ch_3.pdf">Markov Dynamics</a></td>
                             </tr>
                             <tr>
                                 <td>Chapter 4</td>
-                                <td><a href="https://github.com/QuantEcon/book-dp1-public/raw/main/slides/ch_4.pdf">Optimal Stopping</a></td>
+                                <td><a href="https://github.com/QuantEcon/book-dp-public/raw/main/slides/ch_4.pdf">Optimal Stopping</a></td>
                             </tr>
                             <tr>
                                 <td>Chapter 5</td>
-                                <td><a href="https://github.com/QuantEcon/book-dp1-public/raw/main/slides/ch_5.pdf">Markov Decision Processes</a></td>
+                                <td><a href="https://github.com/QuantEcon/book-dp-public/raw/main/slides/ch_5.pdf">Markov Decision Processes</a></td>
                             </tr>
                             <tr>
                                 <td>Chapter 6</td>
-                                <td><a href="https://github.com/QuantEcon/book-dp1-public/raw/main/slides/ch_6.pdf">Stochastic Discounting</a></td>
+                                <td><a href="https://github.com/QuantEcon/book-dp-public/raw/main/slides/ch_6.pdf">Stochastic Discounting</a></td>
                             </tr>
                             <tr>
                                 <td>Chapter 7</td>
-                                <td><a href="https://github.com/QuantEcon/book-dp1-public/raw/main/slides/ch_7.pdf">Valuation</a></td>
+                                <td><a href="https://github.com/QuantEcon/book-dp-public/raw/main/slides/ch_7.pdf">Valuation</a></td>
                             </tr>
                             <tr>
                                 <td>Chapter 8</td>
-                                <td><a href="https://github.com/QuantEcon/book-dp1-public/raw/main/slides/ch_8.pdf">Recursive Decision Processes</a></td>
+                                <td><a href="https://github.com/QuantEcon/book-dp-public/raw/main/slides/ch_8.pdf">Recursive Decision Processes</a></td>
                             </tr>
                             <tr>
                                 <td>Chapter 9</td>
-                                <td><a href="https://github.com/QuantEcon/book-dp1-public/raw/main/slides/ch_9.pdf">Abstract Dynamic Programming</a></td>
+                                <td><a href="https://github.com/QuantEcon/book-dp-public/raw/main/slides/ch_9.pdf">Abstract Dynamic Programming</a></td>
                             </tr>
                             <tr>
                                 <td>Chapter 10</td>
-                                <td><a href="https://github.com/QuantEcon/book-dp1-public/raw/main/slides/ch_10.pdf">Continuous Time</a></td>
+                                <td><a href="https://github.com/QuantEcon/book-dp-public/raw/main/slides/ch_10.pdf">Continuous Time</a></td>
                             </tr>
                         </tbody>
                     </table>
@@ -94,7 +94,7 @@
                 <div class="align-center">
                     <ul class="actions fit">
                         <li>
-                            <a href="https://github.com/QuantEcon/book-dp1-public/" class="button fit"><img src="images/github-mark.png" width="15" alt="GitHub icon">GitHub</a>
+                            <a href="https://github.com/QuantEcon/book-dp-public/" class="button fit"><img src="images/github-mark.png" width="15" alt="GitHub icon">GitHub</a>
                         </li>
                         <li>
                             <a href="https://quantecon.org" class="button fit"><img src="images/qe-logo-small.png" width="25" alt="QuantEcon icon">QuantEcon</a>


### PR DESCRIPTION
## Summary
- Replaces all `github.com/QuantEcon/book-dp1-public/...` references in [website/index.html](website/index.html), [website/code.html](website/code.html), and [website/slides.html](website/slides.html) with the current repo name `book-dp-public`.
- Pure search-and-replace — no behavior change. The old URLs still resolve via GitHub's rename redirect; this just removes the redirect hop and stops new contributions from picking up the stale name by example.

## Coordination with #19
#19 (overview lectures) adds two new links that still use the old `book-dp1-public` pattern (matching the file's prior convention). After #19 lands, this branch should be rebased onto main and those two lines updated in the rebase commit — or merged in either order with a small follow-up commit. Either way, ~2 extra line edits.

## Test plan
- [x] `grep -r book-dp1-public website/` returns nothing on this branch
- [x] Spot-check each rewritten link (PDFs, GitHub root, code tree) loads correctly
- [x] After merge, confirm `https://dp.quantecon.org/` still renders identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)